### PR TITLE
Change default hotel tld 

### DIFF
--- a/hotel-manager@hardpixel.eu/extension.js
+++ b/hotel-manager@hardpixel.eu/extension.js
@@ -44,7 +44,7 @@ var HotelManager = new Lang.Class({
 
   _hotelConfig: function() {
     let config = this._homeDir + '/.hotel/conf.json';
-    let data   = { port: 2000, host: '127.0.0.1', tld: 'dev' };
+    let data   = { port: 2000, host: '127.0.0.1', tld: 'localhost' };
 
     if (GLib.file_test(config, GLib.FileTest.EXISTS)) {
       data = GLib.file_get_contents(config)[1].toString();


### PR DESCRIPTION
Default hotel tld has changed from "dev" to "localhost" as per changes in hotel process manager v0.8.0 upgrade